### PR TITLE
feat(models): 添加剧本杀游戏核心实体模型和枚举类

### DIFF
--- a/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/Character.java
+++ b/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/Character.java
@@ -1,0 +1,42 @@
+package org.jubensha.aijubenshabackend.models.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Entity(name = "CharacterEntity")
+@Table(name = "characters")
+public class Character {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne
+    @JoinColumn(name = "script_id", nullable = false)
+    private Script script;
+    
+    private String name;
+    
+    @Column(columnDefinition = "TEXT")
+    private String description;
+    
+    @Column(columnDefinition = "TEXT")
+    private String backgroundStory;
+    
+    @Column(columnDefinition = "TEXT")
+    private String secret;
+    
+    private String avatar;
+    
+    private Boolean isAi;
+    
+    private LocalDateTime createTime;
+    
+    @PrePersist
+    protected void onCreate() {
+        createTime = LocalDateTime.now();
+    }
+}

--- a/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/Clue.java
+++ b/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/Clue.java
@@ -1,0 +1,44 @@
+package org.jubensha.aijubenshabackend.models.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import org.jubensha.aijubenshabackend.models.enums.ClueType;
+import org.jubensha.aijubenshabackend.models.enums.ClueVisibility;
+
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "clues")
+public class Clue {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne
+    @JoinColumn(name = "script_id", nullable = false)
+    private Script script;
+    
+    private String name;
+    
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String description;
+    
+    @Enumerated(EnumType.STRING)
+    private ClueType type;
+    
+    @Enumerated(EnumType.STRING)
+    private ClueVisibility visibility;
+    
+    private String scene;
+    
+    private Integer importance;
+    
+    private LocalDateTime createTime;
+    
+    @PrePersist
+    protected void onCreate() {
+        createTime = LocalDateTime.now();
+    }
+}

--- a/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/ClueRelation.java
+++ b/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/ClueRelation.java
@@ -1,0 +1,27 @@
+package org.jubensha.aijubenshabackend.models.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "clue_relations")
+public class ClueRelation {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne
+    @JoinColumn(name = "clue_id1", nullable = false)
+    private Clue clue1;
+    
+    @ManyToOne
+    @JoinColumn(name = "clue_id2", nullable = false)
+    private Clue clue2;
+    
+    private Integer strength;
+    
+    @Column(columnDefinition = "TEXT")
+    private String description;
+}

--- a/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/Dialogue.java
+++ b/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/Dialogue.java
@@ -1,0 +1,42 @@
+package org.jubensha.aijubenshabackend.models.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import org.jubensha.aijubenshabackend.models.enums.DialogueType;
+
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "dialogues")
+public class Dialogue {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne
+    @JoinColumn(name = "game_id", nullable = false)
+    private Game game;
+    
+    @ManyToOne
+    @JoinColumn(name = "player_id", nullable = false)
+    private Player player;
+    
+    @ManyToOne
+    @JoinColumn(name = "character_id", nullable = false)
+    private Character character;
+    
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+    
+    @Enumerated(EnumType.STRING)
+    private DialogueType type;
+    
+    private LocalDateTime timestamp;
+    
+    @PrePersist
+    protected void onCreate() {
+        timestamp = LocalDateTime.now();
+    }
+}

--- a/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/Game.java
+++ b/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/Game.java
@@ -1,0 +1,49 @@
+package org.jubensha.aijubenshabackend.models.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import org.jubensha.aijubenshabackend.models.enums.GameStatus;
+import org.jubensha.aijubenshabackend.models.enums.GamePhase;
+
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "games")
+public class Game {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne
+    @JoinColumn(name = "script_id", nullable = false)
+    private Script script;
+    
+    private String gameCode;
+    
+    @Enumerated(EnumType.STRING)
+    private GameStatus status;
+    
+    private LocalDateTime startTime;
+    
+    private LocalDateTime endTime;
+    
+    @Enumerated(EnumType.STRING)
+    private GamePhase currentPhase;
+    
+    private LocalDateTime createTime;
+    
+    private LocalDateTime updateTime;
+    
+    @PrePersist
+    protected void onCreate() {
+        createTime = LocalDateTime.now();
+        updateTime = LocalDateTime.now();
+    }
+    
+    @PreUpdate
+    protected void onUpdate() {
+        updateTime = LocalDateTime.now();
+    }
+}

--- a/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/GamePlayer.java
+++ b/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/GamePlayer.java
@@ -1,0 +1,41 @@
+package org.jubensha.aijubenshabackend.models.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import org.jubensha.aijubenshabackend.models.enums.GamePlayerStatus;
+
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "game_players")
+public class GamePlayer {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne
+    @JoinColumn(name = "game_id", nullable = false)
+    private Game game;
+    
+    @ManyToOne
+    @JoinColumn(name = "player_id", nullable = false)
+    private Player player;
+    
+    @ManyToOne
+    @JoinColumn(name = "character_id", nullable = false)
+    private Character character;
+    
+    private Boolean isDm;
+    
+    @Enumerated(EnumType.STRING)
+    private GamePlayerStatus status;
+    
+    private LocalDateTime joinTime;
+    
+    @PrePersist
+    protected void onCreate() {
+        joinTime = LocalDateTime.now();
+    }
+}

--- a/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/InnerThought.java
+++ b/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/InnerThought.java
@@ -1,0 +1,38 @@
+package org.jubensha.aijubenshabackend.models.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "inner_thoughts")
+public class InnerThought {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne
+    @JoinColumn(name = "game_id", nullable = false)
+    private Game game;
+    
+    @ManyToOne
+    @JoinColumn(name = "player_id", nullable = false)
+    private Player player;
+    
+    @ManyToOne
+    @JoinColumn(name = "character_id", nullable = false)
+    private Character character;
+    
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String content;
+    
+    private LocalDateTime timestamp;
+    
+    @PrePersist
+    protected void onCreate() {
+        timestamp = LocalDateTime.now();
+    }
+}

--- a/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/Player.java
+++ b/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/Player.java
@@ -1,0 +1,49 @@
+package org.jubensha.aijubenshabackend.models.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import org.jubensha.aijubenshabackend.models.enums.PlayerRole;
+import org.jubensha.aijubenshabackend.models.enums.PlayerStatus;
+
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "players")
+public class Player {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    private String username;
+    
+    private String nickname;
+    
+    private String password;
+    
+    private String email;
+    
+    private String avatar;
+    
+    @Enumerated(EnumType.STRING)
+    private PlayerRole role;
+    
+    @Enumerated(EnumType.STRING)
+    private PlayerStatus status;
+    
+    private LocalDateTime createTime;
+    
+    private LocalDateTime updateTime;
+    
+    @PrePersist
+    protected void onCreate() {
+        createTime = LocalDateTime.now();
+        updateTime = LocalDateTime.now();
+    }
+    
+    @PreUpdate
+    protected void onUpdate() {
+        updateTime = LocalDateTime.now();
+    }
+}

--- a/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/PlayerClue.java
+++ b/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/PlayerClue.java
@@ -1,0 +1,37 @@
+package org.jubensha.aijubenshabackend.models.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "player_clues", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"game_id", "player_id", "clue_id"})
+})
+public class PlayerClue {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne
+    @JoinColumn(name = "game_id", nullable = false)
+    private Game game;
+    
+    @ManyToOne
+    @JoinColumn(name = "player_id", nullable = false)
+    private Player player;
+    
+    @ManyToOne
+    @JoinColumn(name = "clue_id", nullable = false)
+    private Clue clue;
+    
+    private LocalDateTime discoveredTime;
+    
+    @PrePersist
+    protected void onCreate() {
+        discoveredTime = LocalDateTime.now();
+    }
+}

--- a/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/Scene.java
+++ b/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/Scene.java
@@ -1,0 +1,37 @@
+package org.jubensha.aijubenshabackend.models.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "scenes")
+public class Scene {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne
+    @JoinColumn(name = "script_id", nullable = false)
+    private Script script;
+    
+    private String name;
+    
+    @Column(columnDefinition = "TEXT", nullable = false)
+    private String description;
+    
+    private String image;
+    
+    @Column(columnDefinition = "TEXT")
+    private String availableActions;
+    
+    private LocalDateTime createTime;
+    
+    @PrePersist
+    protected void onCreate() {
+        createTime = LocalDateTime.now();
+    }
+}

--- a/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/SceneClue.java
+++ b/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/SceneClue.java
@@ -1,0 +1,25 @@
+package org.jubensha.aijubenshabackend.models.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+@Data
+@Entity
+@Table(name = "scene_clues")
+public class SceneClue {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne
+    @JoinColumn(name = "scene_id", nullable = false)
+    private Scene scene;
+    
+    @ManyToOne
+    @JoinColumn(name = "clue_id", nullable = false)
+    private Clue clue;
+    
+    @Column(columnDefinition = "TEXT")
+    private String discoveryCondition;
+}

--- a/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/Script.java
+++ b/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/Script.java
@@ -1,0 +1,51 @@
+package org.jubensha.aijubenshabackend.models.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+import org.jubensha.aijubenshabackend.models.enums.DifficultyLevel;
+
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "scripts")
+public class Script {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    private String name;
+    
+    @Column(columnDefinition = "TEXT")
+    private String description;
+    
+    private String author;
+    
+    @Enumerated(EnumType.STRING)
+    private DifficultyLevel difficulty;
+    
+    private Integer duration;
+    
+    private Integer playerCount;
+    
+    private String coverImage;
+    
+//    @Column(columnDefinition = "LONGTEXT")
+//    private String content;
+    
+    private LocalDateTime createTime;
+    
+    private LocalDateTime updateTime;
+    
+    @PrePersist
+    protected void onCreate() {
+        createTime = LocalDateTime.now();
+        updateTime = LocalDateTime.now();
+    }
+    
+    @PreUpdate
+    protected void onUpdate() {
+        updateTime = LocalDateTime.now();
+    }
+}

--- a/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/SystemSetting.java
+++ b/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/SystemSetting.java
@@ -1,0 +1,33 @@
+package org.jubensha.aijubenshabackend.models.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "system_settings", uniqueConstraints = {
+    @UniqueConstraint(columnNames = {"key_name"})
+})
+public class SystemSetting {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    private String keyName;
+    
+    private String value;
+    
+    @Column(columnDefinition = "TEXT")
+    private String description;
+    
+    private LocalDateTime updateTime;
+    
+    @PrePersist
+    @PreUpdate
+    protected void onUpdate() {
+        updateTime = LocalDateTime.now();
+    }
+}

--- a/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/Vote.java
+++ b/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/entity/Vote.java
@@ -1,0 +1,37 @@
+package org.jubensha.aijubenshabackend.models.entity;
+
+import jakarta.persistence.*;
+import lombok.Data;
+
+import java.time.LocalDateTime;
+
+@Data
+@Entity
+@Table(name = "votes")
+public class Vote {
+    
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+    
+    @ManyToOne
+    @JoinColumn(name = "game_id", nullable = false)
+    private Game game;
+    
+    @ManyToOne
+    @JoinColumn(name = "voter_id", nullable = false)
+    private Player voter;
+    
+    @ManyToOne
+    @JoinColumn(name = "suspect_id", nullable = false)
+    private Character suspect;
+    
+    private Integer phase;
+    
+    private LocalDateTime timestamp;
+    
+    @PrePersist
+    protected void onCreate() {
+        timestamp = LocalDateTime.now();
+    }
+}

--- a/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/enums/AppConstants.java
+++ b/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/enums/AppConstants.java
@@ -1,0 +1,50 @@
+package org.jubensha.aijubenshabackend.models.enums;
+
+/**
+ * 应用程序常量类
+ */
+public class AppConstants {
+    
+    // 系统相关常量
+    public static final String APP_NAME = "AI剧本杀后端系统";
+    public static final String APP_VERSION = "1.0.0";
+    public static final String SYSTEM_USER = "system";
+    
+    // 状态相关常量
+    public static final int STATUS_SUCCESS = 200;
+    public static final int STATUS_ERROR = 500;
+    public static final int STATUS_BAD_REQUEST = 400;
+    public static final int STATUS_UNAUTHORIZED = 401;
+    public static final int STATUS_FORBIDDEN = 403;
+    public static final int STATUS_NOT_FOUND = 404;
+    
+    // 消息相关常量
+    public static final String MESSAGE_SUCCESS = "操作成功";
+    public static final String MESSAGE_ERROR = "操作失败";
+    public static final String MESSAGE_PARAM_ERROR = "参数错误";
+    public static final String MESSAGE_UNAUTHORIZED = "未授权访问";
+    public static final String MESSAGE_FORBIDDEN = "禁止访问";
+    public static final String MESSAGE_NOT_FOUND = "资源不存在";
+    
+    // 游戏相关常量
+    public static final int MAX_PLAYERS = 8;
+    public static final int MIN_PLAYERS = 2;
+    public static final int MAX_SCRIPT_LENGTH = 100000;
+    public static final int MAX_CHARACTER_NAME_LENGTH = 20;
+    
+    // Redis相关常量
+    public static final String REDIS_KEY_PREFIX = "ai_jubensha:";
+    public static final int REDIS_EXPIRE_TIME = 3600; // 1小时
+    
+    // WebSocket相关常量
+    public static final String WEBSOCKET_PATH = "/ws/game";
+    public static final String WEBSOCKET_TOPIC_PREFIX = "/topic/game";
+    
+    // AI相关常量
+    public static final int MAX_AI_RESPONSE_LENGTH = 1000;
+    public static final int MAX_AI_CONTEXT_LENGTH = 10000;
+    
+    // 安全相关常量
+    public static final String SECURITY_ROLE_USER = "ROLE_USER";
+    public static final String SECURITY_ROLE_ADMIN = "ROLE_ADMIN";
+}

--- a/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/enums/ClueType.java
+++ b/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/enums/ClueType.java
@@ -1,0 +1,8 @@
+package org.jubensha.aijubenshabackend.models.enums;
+
+public enum ClueType {
+    PHYSICAL,
+    TESTIMONY,
+    DOCUMENT,
+    OTHER
+}

--- a/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/enums/ClueVisibility.java
+++ b/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/enums/ClueVisibility.java
@@ -1,0 +1,7 @@
+package org.jubensha.aijubenshabackend.models.enums;
+
+public enum ClueVisibility {
+    PUBLIC,
+    DISCOVERED,
+    PRIVATE
+}

--- a/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/enums/DialogueType.java
+++ b/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/enums/DialogueType.java
@@ -1,0 +1,7 @@
+package org.jubensha.aijubenshabackend.models.enums;
+
+public enum DialogueType {
+    CHAT,
+    ACTION,
+    SYSTEM
+}

--- a/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/enums/DifficultyLevel.java
+++ b/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/enums/DifficultyLevel.java
@@ -1,0 +1,7 @@
+package org.jubensha.aijubenshabackend.models.enums;
+
+public enum DifficultyLevel {
+    EASY,
+    MEDIUM,
+    HARD
+}

--- a/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/enums/GamePhase.java
+++ b/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/enums/GamePhase.java
@@ -1,0 +1,9 @@
+package org.jubensha.aijubenshabackend.models.enums;
+
+public enum GamePhase {
+    INTRODUCTION,
+    SEARCH,
+    DISCUSSION,
+    VOTING,
+    ENDING
+}

--- a/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/enums/GamePlayerStatus.java
+++ b/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/enums/GamePlayerStatus.java
@@ -1,0 +1,7 @@
+package org.jubensha.aijubenshabackend.models.enums;
+
+public enum GamePlayerStatus {
+    READY,
+    PLAYING,
+    LEFT
+}

--- a/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/enums/GameStatus.java
+++ b/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/enums/GameStatus.java
@@ -1,0 +1,14 @@
+package org.jubensha.aijubenshabackend.models.enums;
+
+public enum GameStatus {
+    CREATED,
+    STARTED,
+    PAUSED,
+    ENDED,
+    CANCELED;
+
+    @Override
+    public String toString() {
+        return name().toLowerCase();
+    }
+}

--- a/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/enums/PlayerRole.java
+++ b/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/enums/PlayerRole.java
@@ -1,0 +1,6 @@
+package org.jubensha.aijubenshabackend.models.enums;
+
+public enum PlayerRole {
+    USER,
+    ADMIN
+}

--- a/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/enums/PlayerStatus.java
+++ b/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/models/enums/PlayerStatus.java
@@ -1,0 +1,6 @@
+package org.jubensha.aijubenshabackend.models.enums;
+
+public enum PlayerStatus {
+    ONLINE,
+    OFFLINE
+}


### PR DESCRIPTION
- 创建 Character 实体用于管理游戏角色信息
- 创建 Clue 实体用于管理游戏线索数据
- 创建 ClueRelation 实体用于管理线索间关系
- 创建 Dialogue 实体用于记录游戏对话内容
- 创建 Game 实体用于管理游戏实例状态
- 创建 GamePlayer 实体用于管理游戏玩家关联
- 创建 InnerThought 实体用于存储角色内心想法
- 创建 Player 实体用于管理系统玩家账户
- 创建 PlayerClue 实体用于管理玩家发现的线索
- 创建 Scene 实体用于管理游戏场景信息
- 创建 SceneClue 实体用于管理场景中可发现的线索
- 创建 Script 实体用于管理剧本模板数据
- 创建 SystemSetting 实体用于管理系统配置参数
- 创建 Vote 实体用于管理游戏投票记录
- 添加 ClueType、ClueVisibility 等多个枚举类型
- 创建 AppConstants 类统一管理应用程序常量