### PR TITLE
feat(ai): 添加图像搜索工具权限控制接口实现

### DIFF
--- a/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/ai/tools/ImageSearchTool.java
+++ b/ai-jubensha-backend/src/main/java/org/jubensha/aijubenshabackend/ai/tools/ImageSearchTool.java
@@ -9,6 +9,8 @@ import dev.langchain4j.agent.tool.P;
 import dev.langchain4j.agent.tool.Tool;
 import lombok.extern.slf4j.Slf4j;
 import org.jubensha.aijubenshabackend.ai.models.ImageResource;
+import org.jubensha.aijubenshabackend.ai.tools.permission.AgentType;
+import org.jubensha.aijubenshabackend.ai.tools.permission.ToolPermissionLevel;
 import org.jubensha.aijubenshabackend.core.exception.BusinessException;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
@@ -42,6 +44,11 @@ public class ImageSearchTool extends BaseTool {
     @Override
     public String generateToolExecutedResult(JSONObject arguments) {
         return "\n\n[图片获取成功]\n\n";
+    }
+
+    @Override
+    public ToolPermissionLevel getRequiredPermissionLevel(AgentType agentType) {
+        return ToolPermissionLevel.NONE;
     }
 
     @Tool("根据关键词搜索图片")


### PR DESCRIPTION
- 实现 getRequiredPermissionLevel 方法返回 NONE 权限级别
- 为图像搜索功能提供基础权限框架支持